### PR TITLE
Update LAB_01_RBAC.md

### DIFF
--- a/Instructions/Labs/LAB_01_RBAC.md
+++ b/Instructions/Labs/LAB_01_RBAC.md
@@ -227,7 +227,7 @@ In this task, you will create the Service Desk group and assign Dylan to the gro
     az ad group list -o table
     ```
 
-1. In the Bash session within the Cloud Shell pane, run the following to obtain a reference do the user account of Dylan Williams: 
+1. In the Bash session within the Cloud Shell pane, run the following to obtain a reference to the user account of Dylan Williams: 
 
     ```cli
     USER=$(az ad user list --filter "displayname eq 'Dylan Williams'")


### PR DESCRIPTION
Fixed a typo changing "do" to "to" in the following line:
Old - 1. In the Bash session within the Cloud Shell pane, run the following to obtain a reference -> do <- the user account of Dylan Williams
Update - 1. In the Bash session within the Cloud Shell pane, run the following to obtain a reference -> to <- the user account of Dylan Williams

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-