### PR TITLE
Does not deploy "Basic"-tier database as intended

### DIFF
--- a/Allfiles/Labs/10/az-500-10_azuredeploy.json
+++ b/Allfiles/Labs/10/az-500-10_azuredeploy.json
@@ -250,10 +250,11 @@
           "tags": {
             "displayName": "Database"
           },
+          "sku": {
+            "name": "Basic",
+            "tier": "Basic"
+          },
           "properties": {
-            "edition": "[variables('databaseEdition')]",
-            "collation": "[variables('databaseCollation')]",
-            "requestedServiceObjectiveName": "[variables('databaseServiceObjectiveName')]"
           },
           "dependsOn": [
             "[variables('sqlServerName')]"


### PR DESCRIPTION
The portion of the existing ARM template which specifies the database sku.tier (edition) and sku.name (requestedServiceObjectiveName) as “Basic” is not recognized by Azure. When the script is used to deploy the resources, the database defaults to GP_Gen5_2. Testing with our Azure policies shows the Size and tier are not being checked at all. The syntax is valid, but portions are ignored by Azure when deploying the template.

Specifically, the portion below is not being consulted:

          "properties": {
            "edition": "[variables('databaseEdition')]",
            "collation": "[variables('databaseCollation')]",
            "requestedServiceObjectiveName": "[variables('databaseServiceObjectiveName')]"
            }, 

The updated ARM template has been tested and deploys the database as “Basic” tier as expected, and the Azure policy we use, when used in conjunction with the new ARM template, passes only when the tier and name are set to “Basic” in the template.