### PR TITLE
Update LAB_09_ConfiguringandSecuringACRandAKS.MD

### DIFF
--- a/Instructions/Labs/LAB_09_ConfiguringandSecuringACRandAKS.MD
+++ b/Instructions/Labs/LAB_09_ConfiguringandSecuringACRandAKS.MD
@@ -101,7 +101,7 @@ In this task, you will create a Dockerfile, build an image from the Dockerfile, 
     ```sh
     ACRNAME=$(az acr list --resource-group AZ500LAB09 --query '[].{Name:name}' --output tsv)
 
-    az acr build --image sample/nginx:v1 --registry $ACRNAME --file Dockerfile .
+    az acr build --resource-group AZ500LAB09 --image sample/nginx:v1 --registry $ACRNAME --file Dockerfile .
     ```
 
     >**Note**: Wait for the command to successfully complete. This might take about 2 minutes.


### PR DESCRIPTION
need to add "--resource-group AZ500LAB09" so it can find the new ACR added in this RG. Otherwise, Build will fail because ACR not found in the Default RG!  See my post and image capture at https://www.linkedin.com/posts/walterwlee_azure-acr-docker-activity-6862810910126428160-Qo5Q

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-