### PR TITLE
Confusing instruction

### DIFF
--- a/Instructions/Labs/LAB_05_PIM.md
+++ b/Instructions/Labs/LAB_05_PIM.md
@@ -94,7 +94,7 @@ In this task, you will make a user eligible for an Azure AD directory role.
 
 10. Click **Next:Notification**.
 
-11. On the **Edit role setting - Global Reader** blade, review the settings and click **Update**.
+11. Review the **Notification** settings, leave everything set by default and click **Update**.
 
     >**Note**: Anyone trying to use the Global Reader role will now need approval from aaduser3. 
 


### PR DESCRIPTION
Confusing instruction at Exercise 1 > Task 2 > Step 11

On the Edit role setting - Global Reader blade

I think we shouldn't call it a blade, it's the entire panel, which is very confusing. so I simplify it a bit at this step as all learners seem to get stuck finding the blade here for too long

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-