### PR TITLE
docs(LAB_01_RBAC.md): Obtain .id parameter

### DIFF
--- a/Instructions/Labs/LAB_01_RBAC.md
+++ b/Instructions/Labs/LAB_01_RBAC.md
@@ -242,7 +242,7 @@ In this task, you will create the Service Desk group and assign Dylan to the gro
 4. In the Bash session within the Cloud Shell pane, run the following to obtain the objectId property of the user account of Dylan Williams: 
 
     ```cli
-    OBJECTID=$(echo $USER | jq '.[].objectId' | tr -d '"')
+    OBJECTID=$(echo $USER | jq '.[].id' | tr -d '"')
     ```
 
 5. In the Bash session within the Cloud Shell pane, run the following to add the user account of Dylan to the Service Desk group: 


### PR DESCRIPTION
# Module: 01
## Lab: 01

Fixes: The previous command tried to access the .objectId parameter which does not exist in a user object.

Changes proposed in this pull request:

- The correct parameter is accessed with the .id parameter.