### PR TITLE
Update LAB_12_SecuringAzureStorage.MD

### DIFF
--- a/Instructions/Labs/LAB_12_SecuringAzureStorage.MD
+++ b/Instructions/Labs/LAB_12_SecuringAzureStorage.MD
@@ -190,13 +190,6 @@ In this task, you will create a network security group with two outbound securit
     |---|---|
     |Virtual network|**myVirtualNetwork**|
     |Subnet|**Private**|
-
-16. On the **Subnets** blade, select **+ Associate** and specify the following settings in the **Associate subnet** section and then click **OK**:
-
-    |Setting|Value|
-    |---|---|
-    |Virtual network|**myVirtualNetwork**|
-    |Subnet|**Public**|
     
 #### Task 4: Create a storage account with a file share
 


### PR DESCRIPTION
Task 3, point 16 removed otherwise task 7, point 7 will not work.
NetworkSecurityGroup private didn't have to be associated with public subnet.

# Module: 03
## Lab/Demo: 12

Changes proposed in this pull request:

- Removed point 16 of task 3