### PR TITLE
Incorrect location for the Access Policies

### DIFF
--- a/Instructions/Labs/LAB_10_KeyVaultImplementingSecureDatabysettingupAlwaysEncrypted.md
+++ b/Instructions/Labs/LAB_10_KeyVaultImplementingSecureDatabysettingupAlwaysEncrypted.md
@@ -121,7 +121,7 @@ In this task, you will create an Azure Key Vault resource. You will also configu
 
 7. On the Resource Group blade, click the entry representing the newly created Key Vault. 
 
-8. On the Key Vault blade, in the **Settings** section, click **Access Policies** and then click **+ Add Access Policy**.
+8. On the Key Vault blade, in the **Quick Access menu** section, click **Access Policies** and then click **+ Add Access Policy**.
 
 9. On the **Add access policy** blade, specify the following settings (leave all others with their default values): 
 


### PR DESCRIPTION
At least based on the today's UI it is in a different section.

# Module: Module 03 - Secure data and applications
## Lab/Demo: [10 - Key Vault (Implementing Secure Data by setting up Always Encrypted)](https://microsoftlearning.github.io/AZ500-AzureSecurityTechnologies/Instructions/Labs/LAB_10_KeyVaultImplementingSecureDatabysettingupAlwaysEncrypted.html)

Exercise 2: Configure the Key Vault resource with a key and a secret
Task 1: Create and configure a Key Vault
On the Key Vault blade, in the **Settings** section, click Access Policies and then click + Add Access Policy.

Fixes # .

Based on the UI it looks like this;
![image](https://user-images.githubusercontent.com/43988151/194569841-24dc1e28-e855-4674-b5ff-6def2f3ad555.png)


Changes proposed in this pull request:
Replace the "Settings" with "Quick Access Menu".