### PR TITLE
Perhaps "not selected" clarifies better checkboxes

### DIFF
--- a/Instructions/Labs/LAB_12_SecuringAzureStorage.MD
+++ b/Instructions/Labs/LAB_12_SecuringAzureStorage.MD
@@ -331,7 +331,7 @@ In this task, you will create two virtual machines one in the Private subnet and
     |Username|**localadmin**|
     |Password|**Please use your personal password created in Lab 04 > Exercise 1 > Task 1 > Step 9.**|
     |Public inbound ports|**None**|
-    |Already have a Windows Server license|**No**|
+    |Already have a Windows Server license|**Not selected**|
 
     >**Note**: For public inbound ports, we will rely on the precreated NSG. 
 
@@ -366,7 +366,7 @@ In this task, you will create two virtual machines one in the Private subnet and
     |Username|**localadmin**|
     |Password|**Please use your personal password created in Lab 04 > Exercise 1 > Task 1 > Step 9.**|
     |Public inbound ports|**None**|
-    |Already have a Windows Server license|**No**|
+    |Already have a Windows Server license|**Not selected**|
 
     >**Note**: For public inbound ports, we will rely on the precreated NSG. 
 


### PR DESCRIPTION
# Module: Module 03 - Secure data and applications
## Lab/Demo: Lab 12 - Service Endpoints and Securing Storage
Task 6: Deploy virtual machines into the designated subnets
Step: 3 On the Basics tab of the Create a virtual machine blade...
AND
Step: 9 On the Basics tab of the Create a virtual machine blade...

Fixes # .

The UI looks like following:
![image](https://user-images.githubusercontent.com/43988151/195999136-6b061174-07fe-43c6-bd43-c9bf8c20fdb0.png)

So I believe it is better to say "Not selected" instead just "No".

