### PR TITLE
Update LAB_10 SQL connection string password

### DIFF
--- a/Instructions/Labs/LAB_10_KeyVaultImplementingSecureDatabysettingupAlwaysEncrypted.md
+++ b/Instructions/Labs/LAB_10_KeyVaultImplementingSecureDatabysettingupAlwaysEncrypted.md
@@ -310,7 +310,7 @@ The ARM-template deployment in Exercise 1 provisioned an Azure SQL Server instan
 
     >**Note**: The interface includes connection strings for ADO.NET, JDBC, ODBC, PHP, and Go. 
    
-4. Record the **ADO.NET (SQL authentication) Connection String**. You will need it later.
+4. Record the **ADO.NET (SQL authentication)** connection string. You will need it later.
 
     >**Note**: When you use the connection string, make sure to replace the `{your_password}` placeholder with the password that you configured with the deployment in Exercise 1.
 
@@ -458,7 +458,7 @@ You will create a Console application using Visual Studio to load data into the 
 
 10. Return to the RDP session, and in the Visual Studio console, in the **Solution Explorer** window, click **Program.cs** and replace its content with the code you copied into Clipboard.
 
-11. In the Visual Studio window, in the **Program.cs** pane, in line 15, replace the `<connection string noted earlier>` placeholder with the Azure SQL database **ADO.NET** connection string you recorded earlier in the lab. In the connection string, replace the `{your_password}` placehodler, with `Pa55w.rd1234`. If you saved the string on the lab computer, you may need to leave the RDP session to copy the ADO string, then return to the Azure virtual machine to paste it in.
+11. In the Visual Studio window, in the **Program.cs** pane, in line 15, replace the `<connection string noted earlier>` placeholder with the Azure SQL database **ADO.NET** connection string you recorded earlier in the lab. In the connection string, replace the `{your_password}` placehodler, with the password that you specified in the deployment in Exercise 1. If you saved the string on the lab computer, you may need to leave the RDP session to copy the ADO string, then return to the Azure virtual machine to paste it in.
 
 12. In the Visual Studio window, in the **Program.cs** pane, in line 16, replace the `<client id noted earlier>` placeholder with the value of **Application (client) ID** of the registered app you recorded earlier in the lab. 
 


### PR DESCRIPTION
In the ADO.NET connection string, we need to use the "Student" password used in Ex 1, not "Pa55w.rd1234".

# Module: 03
## Lab: 10

NOTE: The connection string password does not matter since the application replaces it, but it may be confusing to instruct the student to add an incorrect one.

Changes proposed in this pull request:

- Fixed **Bold** formatting
- Fixed incorrect connection string password.