### PR TITLE
Update LAB_07_ConfiguringandSecuringACRandAKS.MD

### DIFF
--- a/Instructions/Labs/LAB_07_ConfiguringandSecuringACRandAKS.MD
+++ b/Instructions/Labs/LAB_07_ConfiguringandSecuringACRandAKS.MD
@@ -217,12 +217,14 @@ In this task, you will grant the AKS cluster permission to access the ACR and ma
 
     ```sh
     RG_AKS=AZ500LAB09
-    
-    AKS_VNET_NAME=AZ500LAB09-vnet
+
+    RG_VNET=MC_AZ500LAB09_MyKubernetesCluster_eastus	
+
+    AKS_VNET_NAME=aks-vnet-30198516
     
     AKS_CLUSTER_NAME=MyKubernetesCluster
     
-    AKS_VNET_ID=$(az network vnet show --name $AKS_VNET_NAME --resource-group $RG_AKS --query id -o tsv)
+    AKS_VNET_ID=$(az network vnet show --name $AKS_VNET_NAME --resource-group $RG_VNET --query id -o tsv)
     
     AKS_MANAGED_ID=$(az aks show --name $AKS_CLUSTER_NAME --resource-group $RG_AKS --query identity.principalId -o tsv)
     


### PR DESCRIPTION
The AKS_VNET is created in the new resource group named MC_AZ500LAB09_MyKubernetesCluster_eastus that holds components of the AKS Nodes. Not in the RG_AKS. 
Added RG_VNET and changed references to the VNET.

Not sure how to go about the custom VNET name. 

# Module: AZ-500
## Lab/Demo: 07

Fixes # .
The original bash code results in the following:

az role assignment create --assignee $AKS_MANAGED_ID --role "Contributor" --scope $AKS_VNET_ID ERROR: (ResourceNotFound) The Resource 'Microsoft.Network/virtualNetworks/AZ500LAB09-vnet' under resource group 'AZ500LAB09' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix Code: ResourceNotFound
Message: The Resource 'Microsoft.Network/virtualNetworks/AZ500LAB09-vnet' under resource group 'AZ500LAB09' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix argument --scope: expected one argument

Changes proposed in this pull request:

-
-
-