### PR TITLE
removed hardcoded VM password from template and instructions

### DIFF
--- a/Allfiles/Labs/08/template.json
+++ b/Allfiles/Labs/08/template.json
@@ -2,6 +2,13 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "adminUsername": {
+            "defaultValue": "localadmin",
+            "type": "string"
+        },
+        "adminPassword": {
+            "type": "secureString"
+        },
         "virtualMachines_Srv_Jump_name": {
             "defaultValue": "Srv-Jump",
             "type": "string"
@@ -433,8 +440,8 @@
                 },
                 "osProfile": {
                     "computerName": "[parameters('virtualMachines_Srv_Jump_name')]",
-                    "adminUsername": "localadmin",
-                    "adminPassword" : "Pa55w.rd1234",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword" : "[parameters('adminPassword')]",
                     "windowsConfiguration": {
                         "provisionVMAgent": true,
                         "enableAutomaticUpdates": true
@@ -485,8 +492,8 @@
                 },
                 "osProfile": {
                     "computerName": "[parameters('virtualMachines_Srv_Work_name')]",
-                    "adminUsername": "localadmin",
-                    "adminPassword": "Pa55w.rd1234",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword" : "[parameters('adminPassword')]",
                     "windowsConfiguration": {
                         "provisionVMAgent": true,
                         "enableAutomaticUpdates": true

--- a/Instructions/Labs/LAB_03_AzureFirewall.md
+++ b/Instructions/Labs/LAB_03_AzureFirewall.md
@@ -78,6 +78,7 @@ In this task, you will create a virtual machine by using an ARM template. This v
    |Subscription|the name of the Azure subscription you will be using in this lab|
    |Resource group|click **Create new** and type the name **AZ500LAB08**|
    |Location|**(US) East US**|
+   |adminPassword|A secure password of your own choosing for the virtual machines. Remember the password. You will need it later to connect to the VMs.|
 
     >**Note**: To identify Azure regions where you can provision Azure VMs, refer to [**https://azure.microsoft.com/en-us/regions/offers/**](https://azure.microsoft.com/en-us/regions/offers/)
 
@@ -271,7 +272,7 @@ In this task, you will test the firewall to confirm that it works as expected.
    |Setting|Value|
    |---|---|
    |User name|**localadmin**|
-   |Password|**Pa55w.rd1234**|
+   |Password|The secure password you chose during deployment of the custom template in task 1 step 6.|
 
     >**Note**: The following steps are performed in the Remote Desktop session to the **Srv-Jump** Azure VM. 
 
@@ -288,7 +289,7 @@ In this task, you will test the firewall to confirm that it works as expected.
    |Setting|Value|
    |---|---|
    |User name|**localadmin**|
-   |Password|**Pa55w.rd1234**|
+   |Password|The secure password you chose during deployment of the custom template in task 1 step 6.|
 
     >**Note**: Wait for the Remote Desktop session to be established and the Server Manager interface to load.
 


### PR DESCRIPTION
# Module: 03
## Lab/Demo: 03

Fixes # .
Security upgrade to remove hardcoded username/password combination used on a public IP with enabled RDP ports. Learners now need to specify their own passwords to prevent password spray attacks. 

Changes proposed in this pull request:

- removed hard coded admin password and converted it to a parameter with no default value
- updated lab instructions to reflect change